### PR TITLE
Fix wrong experiment_suite module name

### DIFF
--- a/run_RL.py
+++ b/run_RL.py
@@ -10,7 +10,7 @@ import argparse
 import logging
 
 from carla.driving_benchmark import run_driving_benchmark
-from carla.driving_benchmark.experiment_suite import CoRL2017, BasicExperimentSuite
+from carla.driving_benchmark.experiment_suites import CoRL2017, BasicExperimentSuite
 from agent.runnable_model import A3CAgent
 
 


### PR DESCRIPTION
It was renamed from experiment_suite to experiment_suites in
https://github.com/carla-simulator/carla/commit/ac35e26d8878a8cc7bd36dad5eff843dbcaae998